### PR TITLE
Change input element renaming style

### DIFF
--- a/src/Tree/Menu.jsx
+++ b/src/Tree/Menu.jsx
@@ -7,7 +7,7 @@ function nameGen(name, occupied) {
   let n = 1;
   let newName = name;
   while (occupied && occupied.includes(newName)) {
-    newName = name + '_' + n;
+    newName = name + '#' + n;
     n += 1;
   }
   return newName;


### PR DESCRIPTION
Hi,

I was using this repo as a component for another project of mine, and I found that the logic in the `core.js` file (especially the `getNodeByRjsfId`) could be simplified if we just change the renaming style of similar Menu elements.

Since the node's rjsf-id uses `_` as a separator between properties (templatename_parentname_...), I think using a different separator would be better.

P.S.: Really great work on building this form builder. Great code. :pray: 